### PR TITLE
Made own javascript for portale

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -47,6 +47,24 @@ app.post('/api/mostvisited', async (req, res) => {
 		res.status(400).send("Error");
 	}
 });
+app.post('/api/favoriten' , async (req,res) =>{
+	try{
+		sqlmodule.setFavorite(req.cookies.userid, req.body.Favoriten, req.body.Favoritenlink);
+		res.status(200).send("OK");
+	}catch(error){
+		console.log(error);
+		res.status(400).send("Error");
+	}
+})
+app.get('/api/favoriten' , async (req,res) => {
+	try{
+		let Favoriten = sqlmodule.getAllFavoriten(req.cookies.userid);
+		res.status(200).send(Favoriten);
+	}catch(error){
+		console.log(error);
+		res.status(400).send("Error");
+	}
+})
 
 app.get('/api/comments', async (req, res) => {
 	try {

--- a/server/index.js
+++ b/server/index.js
@@ -97,7 +97,7 @@ app.get('/api/mostvisited' , async(req, res) => {
 	}
 });
 app.get('/', (req, res) => {
-	res.cookie("lastvisited","/index.html",{httpOnly: true, SameSite: "None"});
+	res.cookie("lastvisited","/index",{httpOnly: true, SameSite: "None"});
 	res.sendFile('/html/index.html', { root: 'static' });
 });
 

--- a/server/static/js/portale.js
+++ b/server/static/js/portale.js
@@ -1,0 +1,14 @@
+function onload() {
+    createmeistbesuchte()
+}
+function createmeistbesuchte() { //Diese Funktion muss von jeder Seite per Onload gecallt werden.
+    fetch("/api/mostvisited", {
+        method: "POST",
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+        .catch(err => {
+            console.log(err);
+        })
+}


### PR DESCRIPTION
Die Portaleseite benötigt ein eigenes Javascript im Frontend und kann nicht das meistbesuchte.js weiterverwenden, wenn wir darauf verzichten wollen mehrere Javascripte in eine HTML -Seite einzubinden.